### PR TITLE
fix NPE in UpdateReportImpl

### DIFF
--- a/api/src/main/java/com/redhat/insights/UpdateReportImpl.java
+++ b/api/src/main/java/com/redhat/insights/UpdateReportImpl.java
@@ -18,7 +18,7 @@ public class UpdateReportImpl implements InsightsReport {
   private String idHash = "";
   private final BlockingQueue<JarInfo> updatedJars;
   private final InsightsLogger logger;
-  private Optional<JarInfoSubreport> subreport;
+  private Optional<JarInfoSubreport> subreport = Optional.empty();
   private final InsightsReportSerializer serializer;
 
   public UpdateReportImpl(BlockingQueue<JarInfo> updatedJars, InsightsLogger logger) {


### PR DESCRIPTION
There was not way attribute subreport can be empty, it will either be filled or null (default). If updatedJars are empty, it will remain null and will fail on NPE in getSubreports() method