### PR TITLE
Feat/add multiclient

### DIFF
--- a/api/src/main/java/com/redhat/insights/AbstractTopLevelReportBase.java
+++ b/api/src/main/java/com/redhat/insights/AbstractTopLevelReportBase.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
  * subreport class and a serializer.
  */
 public abstract class AbstractTopLevelReportBase implements InsightsReport {
-  private static final float BYTES_PER_MB = 1048576f;
+  private static final int BYTES_PER_MB = 1048576;
 
   private static final Pattern JSON_WORKAROUND = Pattern.compile("\\\\+$");
 
@@ -133,7 +133,7 @@ public abstract class AbstractTopLevelReportBase implements InsightsReport {
         defaultHost = host.getHostName();
       }
     } catch (UnknownHostException e) {
-      logger.error("Unknown Host in lookup", e);
+      logger.error("Unknown Host in lookup, continuing with localhost", e);
     }
     options.put("system.hostname", defaultHost);
     options.put("jvm.launch_time", System.currentTimeMillis());
@@ -167,9 +167,9 @@ public abstract class AbstractTopLevelReportBase implements InsightsReport {
     options.put("jvm.heap.gc.details", gcDetails.toString());
 
     //        if (instanceName != null) {
-    //            options.put("instance_name", instanceName);
+    //            options.put("instance.name", instanceName);
     //        }
-    //        options.put("app_name", appNames);
+    //        options.put("app.name", appNames);
 
     Package[] packages = getPackages();
     // This is Object[], not String[] b/c toArray() is not a generic method

--- a/api/src/main/java/com/redhat/insights/AbstractTopLevelReportBase.java
+++ b/api/src/main/java/com/redhat/insights/AbstractTopLevelReportBase.java
@@ -61,6 +61,11 @@ public abstract class AbstractTopLevelReportBase implements InsightsReport {
   }
 
   @Override
+  public void decorate(String key, String value) {
+    options.put(key, value);
+  }
+
+  @Override
   public void generateReport(Filtering masking) {
     // FIXME: Should we skip report generation if idHash is already set?
     // The invariant here is that idHash must be the same between CONNECT events from the

--- a/api/src/main/java/com/redhat/insights/InsightsReportController.java
+++ b/api/src/main/java/com/redhat/insights/InsightsReportController.java
@@ -4,16 +4,11 @@ package com.redhat.insights;
 import static com.redhat.insights.http.InsightsHttpClient.gzipReport;
 import static com.redhat.insights.jars.JarUtils.computeSha512;
 
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.redhat.insights.config.InsightsConfiguration;
 import com.redhat.insights.http.InsightsHttpClient;
 import com.redhat.insights.jars.JarInfo;
 import com.redhat.insights.logging.InsightsLogger;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.*;
 import java.util.function.Supplier;
@@ -121,7 +116,8 @@ public final class InsightsReportController {
             InsightsHttpClient httpClient = httpClientSupplier.get();
             if (httpClient.isReadyToSend()) {
               generateCoreReport();
-              String reportJson = serializeReport();
+              httpClient.decorate(report);
+              String reportJson = report.serialize();
               logger.debug(reportJson);
               httpClient.sendInsightsReport(getIdHash() + "_connect.gz", reportJson);
             }
@@ -135,7 +131,7 @@ public final class InsightsReportController {
             if (httpClient.isReadyToSend() || !jarsToSend.isEmpty()) {
               updateReport.setIdHash(getIdHash());
               updateReport.generateReport(masking);
-              String updateJarReportJson = serializeReport(updateReport);
+              String updateJarReportJson = updateReport.serialize();
               logger.debug(updateJarReportJson);
               logger.debug("Sending jars from " + getIdHash());
               httpClient.sendInsightsReport(getIdHash() + "_update.gz", updateJarReportJson);
@@ -154,10 +150,6 @@ public final class InsightsReportController {
     generateAndSetReportIdHash();
   }
 
-  private String serializeReport() {
-    return serializeReport(report);
-  }
-
   /** Forward the shutdown-related calls to the scheduler */
   public void shutdown() {
     scheduler.shutdown();
@@ -174,7 +166,7 @@ public final class InsightsReportController {
    * timestamp for uniqueness here. 2.) this method mutates both the controller and report objects
    */
   void generateAndSetReportIdHash() {
-    String reportJsonNoHash = serializeReport(report);
+    String reportJsonNoHash = report.serialize();
     try {
       if (!idHashHolder.isDone()) {
         String hash = computeSha512(gzipReport(reportJsonNoHash));
@@ -192,34 +184,6 @@ public final class InsightsReportController {
     } catch (InterruptedException | ExecutionException x) {
       throw new InsightsException("Exception while trying to compute ID Hash: ", x);
     }
-  }
-
-  /**
-   * Serializes the supplied report to JSON for transport
-   *
-   * @param report the report object
-   * @return JSON serialized report
-   */
-  public String serializeReport(InsightsReport report) {
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.registerModule(new JavaTimeModule());
-
-    SimpleModule simpleModule =
-        new SimpleModule(
-            "SimpleModule", new Version(1, 0, 0, null, "com.redhat.insights", "runtimes-java"));
-    simpleModule.addSerializer(InsightsReport.class, report.getSerializer());
-    for (InsightsSubreport subreport : report.getSubreports().values()) {
-      simpleModule.addSerializer(subreport.getClass(), subreport.getSerializer());
-    }
-    mapper.registerModule(simpleModule);
-
-    StringWriter writer = new StringWriter();
-    try {
-      mapper.writerWithDefaultPrettyPrinter().writeValue(writer, report);
-    } catch (IOException e) {
-      throw new InsightsException("JSON serialization exception", e);
-    }
-    return writer.toString();
   }
 
   public BlockingQueue<JarInfo> getJarsToSend() {

--- a/api/src/main/java/com/redhat/insights/InsightsReportController.java
+++ b/api/src/main/java/com/redhat/insights/InsightsReportController.java
@@ -117,9 +117,7 @@ public final class InsightsReportController {
             if (httpClient.isReadyToSend()) {
               generateCoreReport();
               httpClient.decorate(report);
-              String reportJson = report.serialize();
-              logger.debug(reportJson);
-              httpClient.sendInsightsReport(getIdHash() + "_connect.gz", reportJson);
+              httpClient.sendInsightsReport(getIdHash() + "_connect.gz", report);
             }
           };
       scheduler.scheduleConnect(sendConnect);
@@ -131,10 +129,7 @@ public final class InsightsReportController {
             if (httpClient.isReadyToSend() || !jarsToSend.isEmpty()) {
               updateReport.setIdHash(getIdHash());
               updateReport.generateReport(masking);
-              String updateJarReportJson = updateReport.serialize();
-              logger.debug(updateJarReportJson);
-              logger.debug("Sending jars from " + getIdHash());
-              httpClient.sendInsightsReport(getIdHash() + "_update.gz", updateJarReportJson);
+              httpClient.sendInsightsReport(getIdHash() + "_update.gz", updateReport);
             }
           };
       scheduler.scheduleJarUpdate(sendNewJarsIfAny);

--- a/api/src/main/java/com/redhat/insights/InsightsReportController.java
+++ b/api/src/main/java/com/redhat/insights/InsightsReportController.java
@@ -120,9 +120,8 @@ public final class InsightsReportController {
           () -> {
             InsightsHttpClient httpClient = httpClientSupplier.get();
             if (httpClient.isReadyToSend()) {
-              report.generateReport(masking);
-              generateAndSetReportIdHash();
-              String reportJson = serializeReport(this.report);
+              generateCoreReport();
+              String reportJson = serializeReport();
               logger.debug(reportJson);
               httpClient.sendInsightsReport(getIdHash() + "_connect.gz", reportJson);
             }
@@ -148,6 +147,15 @@ public final class InsightsReportController {
       scheduler.shutdown();
       throw isx;
     }
+  }
+
+  void generateCoreReport() {
+    report.generateReport(masking);
+    generateAndSetReportIdHash();
+  }
+
+  private String serializeReport() {
+    return serializeReport(report);
   }
 
   /** Forward the shutdown-related calls to the scheduler */

--- a/api/src/main/java/com/redhat/insights/InsightsReportController.java
+++ b/api/src/main/java/com/redhat/insights/InsightsReportController.java
@@ -115,8 +115,7 @@ public final class InsightsReportController {
           () -> {
             InsightsHttpClient httpClient = httpClientSupplier.get();
             if (httpClient.isReadyToSend()) {
-              generateCoreReport();
-              httpClient.decorate(report);
+              generateConnectReport();
               httpClient.sendInsightsReport(getIdHash() + "_connect.gz", report);
             }
           };
@@ -140,7 +139,7 @@ public final class InsightsReportController {
     }
   }
 
-  void generateCoreReport() {
+  void generateConnectReport() {
     report.generateReport(masking);
     generateAndSetReportIdHash();
   }

--- a/api/src/main/java/com/redhat/insights/UpdateReportImpl.java
+++ b/api/src/main/java/com/redhat/insights/UpdateReportImpl.java
@@ -71,4 +71,10 @@ public class UpdateReportImpl implements InsightsReport {
   public String getIdHash() {
     return idHash;
   }
+
+  @Override
+  public void decorate(String key, String value) {
+    logger.warning(
+        String.format("Attempt to add %s => %s to an update report. Ignored.", key, value));
+  }
 }

--- a/api/src/main/java/com/redhat/insights/http/InsightsFileWritingClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsFileWritingClient.java
@@ -28,7 +28,7 @@ public class InsightsFileWritingClient implements InsightsHttpClient {
 
   @Override
   public void sendInsightsReport(String filename, InsightsReport report) {
-    report.decorate("transport.type.file", "rhel");
+    decorate(report);
     String reportJson = report.serialize();
     //    logger.debug(reportJson);
 
@@ -44,24 +44,4 @@ public class InsightsFileWritingClient implements InsightsHttpClient {
       throw new InsightsException("Could not write to: " + p, iox);
     }
   }
-
-  //  public void sendInsightsReport(String filename, String report) {
-  //    // Can't reuse upload path - as this may be called as part of fallback
-  //    Path p = Paths.get(config.getArchiveUploadDir(), filename);
-  //    try {
-  //      Files.write(
-  //          p,
-  //          report.getBytes(StandardCharsets.UTF_8),
-  //          StandardOpenOption.WRITE,
-  //          StandardOpenOption.CREATE);
-  //    } catch (IOException iox) {
-  //      throw new InsightsException("Could not write to: " + p, iox);
-  //    }
-  //  }
-
-  //  @Override
-  //  public void sendInsightsReport(String filename, byte[] gzipReport) {
-  //    throw new InsightsException(
-  //        "Unsupported operation attempted on InsightsFileWritingClient: " + filename);
-  //  }
 }

--- a/api/src/main/java/com/redhat/insights/http/InsightsFileWritingClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsFileWritingClient.java
@@ -2,6 +2,7 @@
 package com.redhat.insights.http;
 
 import com.redhat.insights.InsightsException;
+import com.redhat.insights.InsightsReport;
 import com.redhat.insights.config.InsightsConfiguration;
 import com.redhat.insights.logging.InsightsLogger;
 import java.io.IOException;
@@ -18,6 +19,11 @@ public class InsightsFileWritingClient implements InsightsHttpClient {
   public InsightsFileWritingClient(InsightsLogger logger, InsightsConfiguration config) {
     this.logger = logger;
     this.config = config;
+  }
+
+  @Override
+  public void decorate(InsightsReport report) {
+    report.decorate("transport.type.file", "rhel");
   }
 
   @Override

--- a/api/src/main/java/com/redhat/insights/http/InsightsFileWritingClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsFileWritingClient.java
@@ -27,13 +27,17 @@ public class InsightsFileWritingClient implements InsightsHttpClient {
   }
 
   @Override
-  public void sendInsightsReport(String filename, String report) {
+  public void sendInsightsReport(String filename, InsightsReport report) {
+    report.decorate("transport.type.file", "rhel");
+    String reportJson = report.serialize();
+    //    logger.debug(reportJson);
+
     // Can't reuse upload path - as this may be called as part of fallback
     Path p = Paths.get(config.getArchiveUploadDir(), filename);
     try {
       Files.write(
           p,
-          report.getBytes(StandardCharsets.UTF_8),
+          reportJson.getBytes(StandardCharsets.UTF_8),
           StandardOpenOption.WRITE,
           StandardOpenOption.CREATE);
     } catch (IOException iox) {
@@ -41,9 +45,23 @@ public class InsightsFileWritingClient implements InsightsHttpClient {
     }
   }
 
-  @Override
-  public void sendInsightsReport(String filename, byte[] gzipReport) {
-    throw new InsightsException(
-        "Unsupported operation attempted on InsightsFileWritingClient: " + filename);
-  }
+  //  public void sendInsightsReport(String filename, String report) {
+  //    // Can't reuse upload path - as this may be called as part of fallback
+  //    Path p = Paths.get(config.getArchiveUploadDir(), filename);
+  //    try {
+  //      Files.write(
+  //          p,
+  //          report.getBytes(StandardCharsets.UTF_8),
+  //          StandardOpenOption.WRITE,
+  //          StandardOpenOption.CREATE);
+  //    } catch (IOException iox) {
+  //      throw new InsightsException("Could not write to: " + p, iox);
+  //    }
+  //  }
+
+  //  @Override
+  //  public void sendInsightsReport(String filename, byte[] gzipReport) {
+  //    throw new InsightsException(
+  //        "Unsupported operation attempted on InsightsFileWritingClient: " + filename);
+  //  }
 }

--- a/api/src/main/java/com/redhat/insights/http/InsightsHttpClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsHttpClient.java
@@ -36,8 +36,6 @@ public interface InsightsHttpClient {
    */
   void sendInsightsReport(String filename, InsightsReport report);
 
-  //  void sendInsightsUpdateReport(String filename, InsightsReport report);
-
   /**
    * Indicates if the HttpClient is ready to send the data.
    *

--- a/api/src/main/java/com/redhat/insights/http/InsightsHttpClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsHttpClient.java
@@ -7,6 +7,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPOutputStream;
 
+/**
+ * The main interface used for delivering Insights data (aka archives) to Red Hat. Note that the
+ * interface name contains "Http" because the primary (and desired) transport is over HTTPS.
+ * However, we need to also support a file-based mechanism - but only temporarily - so we don't warp
+ * the interface name.
+ */
 public interface InsightsHttpClient {
 
   public static final String GENERAL_MIME_TYPE =

--- a/api/src/main/java/com/redhat/insights/http/InsightsHttpClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsHttpClient.java
@@ -34,17 +34,9 @@ public interface InsightsHttpClient {
    * @param filename the name of the report.
    * @param report the report payload.
    */
-  default void sendInsightsReport(String filename, String report) {
-    sendInsightsReport(filename, gzipReport(report));
-  }
+  void sendInsightsReport(String filename, InsightsReport report);
 
-  /**
-   * Send the report, which has already been gzipped
-   *
-   * @param filename the name of the report.
-   * @param gzipReport the gzip containing the report payload.
-   */
-  void sendInsightsReport(String filename, byte[] gzipReport);
+  //  void sendInsightsUpdateReport(String filename, InsightsReport report);
 
   /**
    * Indicates if the HttpClient is ready to send the data.

--- a/api/src/main/java/com/redhat/insights/http/InsightsHttpClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsHttpClient.java
@@ -2,6 +2,7 @@
 package com.redhat.insights.http;
 
 import com.redhat.insights.InsightsException;
+import com.redhat.insights.InsightsReport;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -17,6 +18,15 @@ public interface InsightsHttpClient {
 
   public static final String GENERAL_MIME_TYPE =
       "application/vnd.redhat.runtimes-java-general.analytics+tgz";
+
+  /**
+   * Decorates the Insights report with any additional metadata that the client wants sent. This is
+   * a mandatory method, rather than optional, because client implementors should consider what data
+   * they need to convey to the Insights services.
+   *
+   * @param report
+   */
+  void decorate(InsightsReport report);
 
   /**
    * Send the report, which has not been gzipped.
@@ -45,6 +55,12 @@ public interface InsightsHttpClient {
     return true;
   }
 
+  /**
+   * Static gzip helper method
+   *
+   * @param report
+   * @return gzipped bytes
+   */
   static byte[] gzipReport(final String report) {
     try (final ByteArrayOutputStream baos = new ByteArrayOutputStream(report.length())) {
       final byte[] buffy = report.getBytes(StandardCharsets.UTF_8);

--- a/api/src/main/java/com/redhat/insights/http/InsightsMultiClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsMultiClient.java
@@ -30,9 +30,6 @@ public class InsightsMultiClient implements InsightsHttpClient {
   @Override
   public void decorate(InsightsReport report) {
     logger.warning("Multiclients do not support direct decoration of reports");
-    //    for (InsightsHttpClient client : clients) {
-    //      client.decorate(report);
-    //    }
   }
 
   @Override
@@ -53,9 +50,4 @@ public class InsightsMultiClient implements InsightsHttpClient {
     }
     throw new InsightsException("All clients failed: " + clients);
   }
-
-  //  @Override
-  //  public void sendInsightsReport(String filename, byte[] gzipReport) {
-  //    throw new InsightsException("Multiclients do not support direct send of compressed data");
-  //  }
 }

--- a/api/src/main/java/com/redhat/insights/http/InsightsMultiClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsMultiClient.java
@@ -1,0 +1,49 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.insights.http;
+
+import com.redhat.insights.InsightsException;
+import com.redhat.insights.logging.InsightsLogger;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * An implementation of the Insights client interface that can try multiple connection paths. This
+ * includes the expected primary use case of HTTPS, then File.
+ */
+public class InsightsMultiClient implements InsightsHttpClient {
+  private final InsightsLogger logger;
+  private final List<InsightsHttpClient> clients;
+
+  public InsightsMultiClient(InsightsLogger logger, List<InsightsHttpClient> clients) {
+    this.logger = logger;
+    this.clients = clients;
+  }
+
+  public InsightsMultiClient(InsightsLogger logger, InsightsHttpClient... clients) {
+    this.logger = logger;
+    this.clients = Arrays.asList(clients);
+  }
+
+  @Override
+  public void sendInsightsReport(String filename, String report) {
+    String previousExceptionMsg = "";
+    for (InsightsHttpClient client : clients) {
+      try {
+        client.sendInsightsReport(filename + previousExceptionMsg, report);
+        return;
+      } catch (InsightsException x) {
+        logger.debug("Client failed, trying next", x);
+        byte[] msgBytes = x.getMessage().getBytes(StandardCharsets.UTF_8);
+        previousExceptionMsg = "__" + Base64.getEncoder().encodeToString(msgBytes);
+      }
+    }
+    throw new InsightsException("All clients failed: " + clients);
+  }
+
+  @Override
+  public void sendInsightsReport(String filename, byte[] gzipReport) {
+    throw new InsightsException("Multiclients do not support direct send of compressed data");
+  }
+}

--- a/api/src/main/java/com/redhat/insights/http/InsightsMultiClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsMultiClient.java
@@ -4,9 +4,7 @@ package com.redhat.insights.http;
 import com.redhat.insights.InsightsException;
 import com.redhat.insights.InsightsReport;
 import com.redhat.insights.logging.InsightsLogger;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.List;
 
 /**
@@ -44,8 +42,7 @@ public class InsightsMultiClient implements InsightsHttpClient {
         return;
       } catch (InsightsException x) {
         logger.debug("Client failed, trying next", x);
-        byte[] msgBytes = x.getMessage().getBytes(StandardCharsets.UTF_8);
-        previousExceptionMsg = Base64.getEncoder().encodeToString(msgBytes);
+        previousExceptionMsg = x.getMessage();
       }
     }
     throw new InsightsException("All clients failed: " + clients);

--- a/api/src/main/java/com/redhat/insights/http/InsightsMultiClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsMultiClient.java
@@ -2,6 +2,7 @@
 package com.redhat.insights.http;
 
 import com.redhat.insights.InsightsException;
+import com.redhat.insights.InsightsReport;
 import com.redhat.insights.logging.InsightsLogger;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -24,6 +25,13 @@ public class InsightsMultiClient implements InsightsHttpClient {
   public InsightsMultiClient(InsightsLogger logger, InsightsHttpClient... clients) {
     this.logger = logger;
     this.clients = Arrays.asList(clients);
+  }
+
+  @Override
+  public void decorate(InsightsReport report) {
+    for (InsightsHttpClient client : clients) {
+      client.decorate(report);
+    }
   }
 
   @Override

--- a/api/src/test/java/com/redhat/insights/InsightsReportControllerSimpleThreadingTest.java
+++ b/api/src/test/java/com/redhat/insights/InsightsReportControllerSimpleThreadingTest.java
@@ -52,7 +52,7 @@ public class InsightsReportControllerSimpleThreadingTest {
     report.generateReport(Filtering.DEFAULT);
 
     // First, compute the SHA 512 fingerprint without the id hash
-    String initialReportJson = controller.serializeReport(report);
+    String initialReportJson = report.serialize();
     final byte[] initialGz = gzipReport(initialReportJson);
     final String hash = computeSha512(initialGz);
 
@@ -64,7 +64,7 @@ public class InsightsReportControllerSimpleThreadingTest {
     assertEquals(controller.getIdHash(), hash);
 
     // Reserialize with the hash
-    final String reportJson = controller.serializeReport(report);
+    final String reportJson = report.serialize();
     final byte[] finalGz = gzipReport(reportJson);
 
     assertNotEquals(initialReportJson, reportJson);

--- a/api/src/test/java/com/redhat/insights/InsightsReportControllerTest.java
+++ b/api/src/test/java/com/redhat/insights/InsightsReportControllerTest.java
@@ -1,19 +1,17 @@
 /* Copyright (C) Red Hat 2022-2023 */
 package com.redhat.insights;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.redhat.insights.config.InsightsConfiguration;
+import com.redhat.insights.doubles.DummyTopLevelReport;
 import com.redhat.insights.doubles.MockInsightsConfiguration;
 import com.redhat.insights.doubles.NoopInsightsHttpClient;
 import com.redhat.insights.doubles.NoopInsightsLogger;
 import com.redhat.insights.http.InsightsHttpClient;
 import com.redhat.insights.logging.InsightsLogger;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -29,14 +27,26 @@ public class InsightsReportControllerTest {
     InsightsHttpClient httpClient = new NoopInsightsHttpClient();
     InsightsLogger logger = new NoopInsightsLogger();
     InsightsConfiguration config = MockInsightsConfiguration.ofOptedOut("test_app");
-    InsightsReport report = mock(InsightsReport.class);
-    when(report.getSerializer()).thenReturn(new InsightsReportSerializer());
-    when(report.getSubreports()).thenReturn(Collections.emptyMap());
-    when(report.getBasic()).thenReturn(Collections.singletonMap("test", "value"));
+    AtomicInteger count = new AtomicInteger();
+    InsightsReport report =
+        new DummyTopLevelReport(logger, Collections.emptyMap()) {
+          @Override
+          public void setIdHash(String idHash) {
+            count.incrementAndGet();
+            super.setIdHash(idHash);
+          }
+        };
+    // This should be done with a mock (or some sort of intercepting double), but I can't quite see
+    // how
+    //    InsightsReport report = mock(InsightsReport.class);
+    //    when(report.getSerializer()).thenReturn(new InsightsReportSerializer());
+    //    when(report.getSubreports()).thenReturn(Collections.emptyMap());
+    //    when(report.getBasic()).thenReturn(Collections.singletonMap("test", "value"));
     InsightsReportController instance =
         InsightsReportController.of(logger, config, report, () -> httpClient);
     instance.generateAndSetReportIdHash();
     instance.generateAndSetReportIdHash();
-    verify(report, times(1)).setIdHash(anyString());
+    assertEquals(1, count.get());
+    //    verify(report, times(1)).setIdHash(anyString());
   }
 }

--- a/api/src/test/java/com/redhat/insights/doubles/DummyTopLevelReport.java
+++ b/api/src/test/java/com/redhat/insights/doubles/DummyTopLevelReport.java
@@ -40,12 +40,11 @@ public class DummyTopLevelReport extends AbstractTopLevelReportBase {
     return super.getBasic();
   }
 
+  @Override
+  public void decorate(String key, String value) {}
+
   public static DummyTopLevelReport of(InsightsLogger logger) {
-    return new DummyTopLevelReport(
-        logger, Collections.emptyMap()
-        //        Collections.<String, InsightsSubreport>unmodifiableMap(
-        //            "details", new AppInsightsSubreport())
-        );
+    return new DummyTopLevelReport(logger, Collections.emptyMap());
   }
 
   public Map<String, String> getNecessary() {

--- a/api/src/test/java/com/redhat/insights/doubles/NoopInsightsHttpClient.java
+++ b/api/src/test/java/com/redhat/insights/doubles/NoopInsightsHttpClient.java
@@ -1,9 +1,13 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.insights.doubles;
 
+import com.redhat.insights.InsightsReport;
 import com.redhat.insights.http.InsightsHttpClient;
 
 public final class NoopInsightsHttpClient implements InsightsHttpClient {
+  @Override
+  public void decorate(InsightsReport report) {}
+
   @Override
   public void sendInsightsReport(String filename, byte[] gzipReport) {
     return;

--- a/api/src/test/java/com/redhat/insights/doubles/NoopInsightsHttpClient.java
+++ b/api/src/test/java/com/redhat/insights/doubles/NoopInsightsHttpClient.java
@@ -5,11 +5,12 @@ import com.redhat.insights.InsightsReport;
 import com.redhat.insights.http.InsightsHttpClient;
 
 public final class NoopInsightsHttpClient implements InsightsHttpClient {
+
   @Override
   public void decorate(InsightsReport report) {}
 
   @Override
-  public void sendInsightsReport(String filename, byte[] gzipReport) {
+  public void sendInsightsReport(String filename, InsightsReport report) {
     return;
   }
 }

--- a/api/src/test/java/com/redhat/insights/http/InsightsFileWritingClientTest.java
+++ b/api/src/test/java/com/redhat/insights/http/InsightsFileWritingClientTest.java
@@ -2,7 +2,10 @@
 package com.redhat.insights.http;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.redhat.insights.InsightsReport;
 import com.redhat.insights.config.InsightsConfiguration;
 import com.redhat.insights.doubles.NoopInsightsLogger;
 import com.redhat.insights.logging.InsightsLogger;
@@ -30,7 +33,10 @@ public class InsightsFileWritingClientTest {
 
     InsightsLogger logger = new NoopInsightsLogger();
     InsightsHttpClient client = new InsightsFileWritingClient(logger, cfg);
-    client.sendInsightsReport("foo.txt", "foo");
+    InsightsReport report = mock(InsightsReport.class);
+    when(report.serialize()).thenReturn("foo");
+
+    client.sendInsightsReport("foo.txt", report);
     File[] files = tmpdir.toFile().listFiles();
     assertEquals(1, files.length);
     assertEquals(3, files[0].length());

--- a/jboss-cert-helper/main.go
+++ b/jboss-cert-helper/main.go
@@ -1,99 +1,99 @@
 package main
 
 import (
-  "errors"
-  "fmt"
-  "log"
-  "os"
-  "os/user"
-  "syscall"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+	"syscall"
 )
 
 const (
-  certPath      = "/etc/pki/consumer/cert.pem"
-  keyPath       = "/etc/pki/consumer/key.pem"
-  validUsername = "jboss"
+	certPath      = "/etc/pki/consumer/cert.pem"
+	keyPath       = "/etc/pki/consumer/key.pem"
+	validUsername = "jboss"
 )
 
 const usageError = "incorrect usage"
 
 const (
-  errCurrentUser   = 1
-  errIncorrectUser = 2
-  errWrongArgs     = 3
-  errNotSetuid     = 4
-  errCertOrKey     = 5
-  errFileRead      = 6
+	errCurrentUser   = 1
+	errIncorrectUser = 2
+	errWrongArgs     = 3
+	errNotSetuid     = 4
+	errCertOrKey     = 5
+	errFileRead      = 6
 )
 
 func main() {
-  ensureCorrectUser()
-  ensureOneArgument()
-  setUidForRead()
-  readAndPrint(os.Args[1])
+	ensureCorrectUser()
+	ensureOneArgument()
+	setUidForRead()
+	readAndPrint(os.Args[1])
 }
 
 func fail(code int, message string) {
-  log.Println(message)
-  os.Exit(code)
+	log.Println(message)
+	os.Exit(code)
 }
 
 func ensureCorrectUser() {
-  current, err := user.Current()
-  if err != nil {
-    fail(errCurrentUser, err.Error())
-  }
-  if current.Username != validUsername {
-    fail(errIncorrectUser, fmt.Sprint("Incorrect current ", current.Username))
-  }
+	current, err := user.Current()
+	if err != nil {
+		fail(errCurrentUser, err.Error())
+	}
+	if current.Username != validUsername {
+		fail(errIncorrectUser, fmt.Sprint("Incorrect current ", current.Username))
+	}
 }
 
 func ensureOneArgument() {
-  if len(os.Args) != 2 {
-    fail(errWrongArgs, usageError)
-  }
+	if len(os.Args) != 2 {
+		fail(errWrongArgs, usageError)
+	}
 }
 
 func setUidForRead() {
-  ruid := syscall.Getuid()
-  // The binary expects to be setuid, be we have to actually change EUID to root
-  err := syscall.Setreuid(ruid, 0)
-  if err != nil {
-    fail(errNotSetuid, err.Error())
-  }
-  // TODO Do we actually want to print this?
-  ruid = syscall.Getuid()
-  euid := syscall.Geteuid()
-  fmt.Println(ruid, " ", euid)
+	ruid := syscall.Getuid()
+	// The binary expects to be setuid, be we have to actually change EUID to root
+	err := syscall.Setreuid(ruid, 0)
+	if err != nil {
+		fail(errNotSetuid, err.Error())
+	}
+	// TODO Do we actually want to print this?
+	//ruid = syscall.Getuid()
+	//euid := syscall.Geteuid()
+	//fmt.Println(ruid, " ", euid)
 }
 
 func readAndPrint(s string) {
-  path, err := selectFile(s)
-  if err != nil {
-    fail(errCertOrKey, err.Error())
-  }
-  data, err := readFile(path)
-  if err != nil {
-    fail(errFileRead, err.Error())
-  }
-  fmt.Println(data)
+	path, err := selectFile(s)
+	if err != nil {
+		fail(errCertOrKey, err.Error())
+	}
+	data, err := readFile(path)
+	if err != nil {
+		fail(errFileRead, err.Error())
+	}
+	fmt.Println(data)
 }
 
 func selectFile(argument string) (string, error) {
-  switch argument {
-  case "--cert":
-    return certPath, nil
-  case "--key":
-    return keyPath, nil
-  default:
-    return "", errors.New(usageError)
-  }
+	switch argument {
+	case "--cert":
+		return certPath, nil
+	case "--key":
+		return keyPath, nil
+	default:
+		return "", errors.New(usageError)
+	}
 }
 
 func readFile(path string) (string, error) {
-  data, err := os.ReadFile(path)
-  if err != nil {
-    return "", err
-  }
-  return string(data), nil
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }

--- a/runtime/src/main/java/com/redhat/insights/core/httpclient/InsightsJdkHttpClient.java
+++ b/runtime/src/main/java/com/redhat/insights/core/httpclient/InsightsJdkHttpClient.java
@@ -88,9 +88,11 @@ public class InsightsJdkHttpClient implements InsightsHttpClient {
   }
 
   @Override
-  public void sendInsightsReport(String filename, byte[] gzipReport) {
+  public void sendInsightsReport(String filename, InsightsReport report) {
+    decorate(report);
     final var client = getHttpClient();
-    sendInsightsReportWithClient(client, filename, gzipReport);
+    final var gzipJson = InsightsHttpClient.gzipReport(report.serialize());
+    sendInsightsReportWithClient(client, filename, gzipJson);
   }
 
   protected void sendInsightsReportWithClient(

--- a/runtime/src/test/java/com/redhat/insights/core/agent/ClassNoticerTest.java
+++ b/runtime/src/test/java/com/redhat/insights/core/agent/ClassNoticerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import com.redhat.insights.InsightsCustomScheduledExecutor;
+import com.redhat.insights.InsightsReport;
 import com.redhat.insights.InsightsReportController;
 import com.redhat.insights.core.app.AppTopLevelReport;
 import com.redhat.insights.doubles.MockInsightsConfiguration;
@@ -50,6 +51,7 @@ public class ClassNoticerTest {
         .atMost(Duration.ofSeconds(20))
         .untilAsserted(
             () ->
-                Mockito.verify(mockHttpClient, times(2)).sendInsightsReport(any(), (String) any()));
+                Mockito.verify(mockHttpClient, times(2))
+                    .sendInsightsReport(any(), (InsightsReport) any()));
   }
 }

--- a/runtime/src/test/java/com/redhat/insights/core/httpclient/MockInsightsJdkHttpClient.java
+++ b/runtime/src/test/java/com/redhat/insights/core/httpclient/MockInsightsJdkHttpClient.java
@@ -1,7 +1,9 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.insights.core.httpclient;
 
+import com.redhat.insights.InsightsReport;
 import com.redhat.insights.config.InsightsConfiguration;
+import com.redhat.insights.http.InsightsHttpClient;
 import com.redhat.insights.logging.InsightsLogger;
 import java.net.http.HttpClient;
 import java.util.function.Supplier;
@@ -20,7 +22,8 @@ public class MockInsightsJdkHttpClient extends InsightsJdkHttpClient {
   }
 
   @Override
-  public void sendInsightsReport(String filename, byte[] gzipReport) {
-    sendInsightsReportWithClient(mock, filename, gzipReport);
+  public void sendInsightsReport(String filename, InsightsReport report) {
+    var gzipJson = InsightsHttpClient.gzipReport(report.serialize());
+    sendInsightsReportWithClient(mock, filename, gzipJson);
   }
 }


### PR DESCRIPTION
* Adds multiclient
* Refactors to allow report decoration by the client
  - This allows previous failure attempts to be recorded and sent up
  - Significant cleanup of the closures that actually do the report sending 