### PR TITLE
Send update event only if http client is ready

### DIFF
--- a/api/src/main/java/com/redhat/insights/InsightsReportController.java
+++ b/api/src/main/java/com/redhat/insights/InsightsReportController.java
@@ -125,7 +125,7 @@ public final class InsightsReportController {
       Runnable sendNewJarsIfAny =
           () -> {
             InsightsHttpClient httpClient = httpClientSupplier.get();
-            if (httpClient.isReadyToSend() || !jarsToSend.isEmpty()) {
+            if (httpClient.isReadyToSend()) {
               updateReport.setIdHash(getIdHash());
               updateReport.generateReport(masking);
               httpClient.sendInsightsReport(getIdHash() + "_update.gz", updateReport);

--- a/api/src/main/java/com/redhat/insights/InsightsReportController.java
+++ b/api/src/main/java/com/redhat/insights/InsightsReportController.java
@@ -125,7 +125,7 @@ public final class InsightsReportController {
       Runnable sendNewJarsIfAny =
           () -> {
             InsightsHttpClient httpClient = httpClientSupplier.get();
-            if (httpClient.isReadyToSend()) {
+            if (httpClient.isReadyToSend() && !jarsToSend.isEmpty()) {
               updateReport.setIdHash(getIdHash());
               updateReport.generateReport(masking);
               httpClient.sendInsightsReport(getIdHash() + "_update.gz", updateReport);


### PR DESCRIPTION
Change controller's behaviour to only send update reports if http client is ready.
Current behaviour doesn't make sense to me. We're sending update reports always, just because httpClient can, no matter if any jars changed. But when some jars do change, we want to send it, even though client can't send it.