### PR TITLE
Log the reason why direct read of cert failed before falling back to cert helper binary

### DIFF
--- a/api/src/main/java/com/redhat/insights/tls/PEMSupport.java
+++ b/api/src/main/java/com/redhat/insights/tls/PEMSupport.java
@@ -74,7 +74,14 @@ public class PEMSupport {
       return Files.readAllBytes(Paths.get(pathStr));
     } catch (IOException iox) {
       // Direct read failed - try to use the helper, if configured
-      logger.debug("Direct read failed - trying to use the helper");
+      logger.debug("Direct read of cert and key failed.", iox);
+      logger.debug(
+          "Trying to use the helper binary "
+              + configuration.getCertHelperBinary()
+              + " to read default cert: "
+              + InsightsConfiguration.DEFAULT_RHEL_CERT_FILE_PATH
+              + " and key: "
+              + InsightsConfiguration.DEFAULT_RHEL_CERT_FILE_PATH);
       CertHelper helper = new CertHelper(logger, configuration);
 
       try {


### PR DESCRIPTION
In case that there is set custom cert/key location and there is any issue with it then do not swallow the reason why reading it failed (bad path, non-readable). Also provide more info when falling back to cert help binary.

