### PR TITLE
Add useEnvVars to allow use of system configured Go

### DIFF
--- a/jboss-cert-helper/pom.xml
+++ b/jboss-cert-helper/pom.xml
@@ -25,6 +25,9 @@
         <artifactId>mvn-golang-wrapper</artifactId>
         <version>${mvn-golang-wrapper.version}</version>
         <extensions>true</extensions>
+        <configuration>
+          <useEnvVars>true</useEnvVars>
+        </configuration>
         <executions>
           <execution>
             <id>default-build</id>


### PR DESCRIPTION
This configuration allows the build to check the env for an existing GOROOT which allows the build to use a system wide install of Go vs downloading the SDK (which is not approved and gets blocked by the firewall in prod builds).

If you want to test this you can clear your ~/.mvnGoLang where the SDKs get downloaded usually (for me on Mac at least) and set GOROOT to the expected value before running the build, it shouldn't download anything and you should not see entries in the build log about reaching out to urls like `https://storage.googleapis.com`.