### PR TITLE
[MWTELE-47]: If the certificates aren't valid we shouldn't provide a SSLContext.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -77,7 +77,6 @@
       <artifactId>system-stubs-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
   <build>
 
@@ -91,7 +90,6 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>${spotless-maven-plugin.version}</version>
         <configuration>
           <skip>${skip.spotless}</skip>
           <!-- optional: limit format enforcement to just the files changed by this feature branch -->

--- a/api/src/main/java/com/redhat/insights/tls/PEMSupport.java
+++ b/api/src/main/java/com/redhat/insights/tls/PEMSupport.java
@@ -14,8 +14,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.*;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 import javax.net.ssl.KeyManagerFactory;
@@ -96,14 +96,15 @@ public class PEMSupport {
     char[] keystorePassword = new char[0];
     try {
 
-      Certificate[] certificates =
-          parsePemData(Certificate.class, certPemData).toArray(new Certificate[0]);
+      X509Certificate[] certificates =
+          parsePemData(X509Certificate.class, certPemData).toArray(new X509Certificate[0]);
       List<PrivateKey> keys = parsePemData(PrivateKey.class, keyPemData);
 
       KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
       keyStore.load(null);
 
       for (int i = 0; i < certificates.length; i++) {
+        certificates[i].checkValidity();
         keyStore.setCertificateEntry("cert-" + i, certificates[i]);
       }
 

--- a/api/src/test/java/com/redhat/insights/tls/PEMSupportTest.java
+++ b/api/src/test/java/com/redhat/insights/tls/PEMSupportTest.java
@@ -1,24 +1,115 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.insights.tls;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import com.redhat.insights.InsightsException;
 import com.redhat.insights.doubles.DefaultConfiguration;
 import com.redhat.insights.logging.TestLogger;
 import java.io.IOException;
 import java.nio.file.*;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.X509Certificate;
+import java.time.ZonedDateTime;
+import javax.security.auth.x500.X500Principal;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.wildfly.common.bytes.ByteStringBuilder;
+import org.wildfly.security.pem.Pem;
+import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
+import org.wildfly.security.x500.cert.X509CertificateBuilder;
 
 public class PEMSupportTest {
 
   @Test
-  public void testLoadingCertAndKey() {
-    new PEMSupport(new TestLogger(), new DefaultConfiguration())
-        .createTLSContext(
-            getPathFromResource("com/redhat/insights/tls/dummy.cert"),
-            getPathFromResource("com/redhat/insights/tls/dummy.key"));
+  public void testLoadingCertAndKey()
+      throws NoSuchAlgorithmException, CertificateException, IOException {
+    SelfSignedX509CertificateAndSigningKey ca =
+        SelfSignedX509CertificateAndSigningKey.builder()
+            .setDn(
+                new X500Principal(
+                    "O=Root Certificate Authority, EMAILADDRESS=elytron@wildfly.org, C=UK,"
+                        + " ST=Elytron, CN=Elytron CA"))
+            .setKeyAlgorithmName("RSA")
+            .setSignatureAlgorithmName("SHA256withRSA")
+            .addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647")
+            .build();
+    KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+    KeyPair generatedKeys = keyPairGenerator.generateKeyPair();
+    PublicKey publicKey = generatedKeys.getPublic();
+    X509Certificate subjectCertificate =
+        new X509CertificateBuilder()
+            .setIssuerDn(ca.getSelfSignedCertificate().getIssuerX500Principal())
+            .setSubjectDn(new X500Principal("O=Elytron, OU=Elytron, C=UK, ST=Elytron, CN=Firefly"))
+            .setSignatureAlgorithmName("SHA256withRSA")
+            .setSigningKey(ca.getSigningKey())
+            .setNotValidBefore(ZonedDateTime.now().minusYears(1))
+            .setNotValidAfter(ZonedDateTime.now().plusYears(1))
+            .setPublicKey(publicKey)
+            .build();
+    ByteStringBuilder target = new ByteStringBuilder();
+    Pem.generatePemX509Certificate(target, ca.getSelfSignedCertificate());
+    Pem.generatePemX509Certificate(target, subjectCertificate);
+    Path pemFile =
+        getPathFromResource("com/redhat/insights/tls/dummy.cert").resolveSibling("pem.cert");
+    Path keyFile =
+        getPathFromResource("com/redhat/insights/tls/dummy.key").resolveSibling("pem.key");
+    Files.write(pemFile, target.toArray());
+    Files.write(keyFile, generatedKeys.getPrivate().getEncoded());
+    new PEMSupport(new TestLogger(), new DefaultConfiguration()).createTLSContext(pemFile, keyFile);
+  }
+
+  @Test
+  public void testLoadingCertAndKeyOutOfDate()
+      throws NoSuchAlgorithmException, CertificateException, IOException {
+    SelfSignedX509CertificateAndSigningKey ca =
+        SelfSignedX509CertificateAndSigningKey.builder()
+            .setDn(
+                new X500Principal(
+                    "O=Root Certificate Authority, EMAILADDRESS=elytron@wildfly.org, C=UK,"
+                        + " ST=Elytron, CN=Elytron CA"))
+            .setKeyAlgorithmName("RSA")
+            .setSignatureAlgorithmName("SHA256withRSA")
+            .addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647")
+            .build();
+    KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+    KeyPair generatedKeys = keyPairGenerator.generateKeyPair();
+    PublicKey publicKey = generatedKeys.getPublic();
+    X509Certificate subjectCertificate =
+        new X509CertificateBuilder()
+            .setIssuerDn(ca.getSelfSignedCertificate().getIssuerX500Principal())
+            .setSubjectDn(new X500Principal("O=Elytron, OU=Elytron, C=UK, ST=Elytron, CN=Firefly"))
+            .setSignatureAlgorithmName("SHA256withRSA")
+            .setSigningKey(ca.getSigningKey())
+            .setNotValidBefore(ZonedDateTime.now().minusYears(2))
+            .setNotValidAfter(ZonedDateTime.now().minusYears(1))
+            .setPublicKey(publicKey)
+            .build();
+    ByteStringBuilder target = new ByteStringBuilder();
+    Pem.generatePemX509Certificate(target, ca.getSelfSignedCertificate());
+    Pem.generatePemX509Certificate(target, subjectCertificate);
+    Path pemFile =
+        getPathFromResource("com/redhat/insights/tls/dummy.cert")
+            .resolveSibling("out-of-date.cert");
+    Path keyFile =
+        getPathFromResource("com/redhat/insights/tls/dummy.key").resolveSibling("out-of-date.key");
+    Files.write(pemFile, target.toArray());
+    Files.write(keyFile, generatedKeys.getPrivate().getEncoded());
+    InsightsException exception =
+        Assertions.assertThrows(
+            InsightsException.class,
+            () ->
+                new PEMSupport(new TestLogger(), new DefaultConfiguration())
+                    .createTLSContext(pemFile, keyFile));
+
+    Assertions.assertEquals("I4ASR0015: SSLContext creation error", exception.getMessage());
+    Assertions.assertTrue(exception.getCause() instanceof CertificateExpiredException);
+    Assertions.assertTrue(
+        exception.getCause().getMessage().startsWith("NotAfter:"),
+        exception.getCause().getMessage());
   }
 
   @Test


### PR DESCRIPTION
 * Verifying the pem certificates before creating the SSLContext.

Jira: https://issues.redhat.com/browse/MWTELE-47