### PR TITLE
Fix the file writing client readiness

### DIFF
--- a/api/src/main/java/com/redhat/insights/http/InsightsFileWritingClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsFileWritingClient.java
@@ -50,8 +50,7 @@ public class InsightsFileWritingClient implements InsightsHttpClient {
 
   @Override
   public boolean isReadyToSend() {
-    return (new File(config.getCertFilePath()).exists()
-            && new File(config.getKeyFilePath()).exists())
-        && new File(config.getMachineIdFilePath()).exists();
+    return (new File(config.getArchiveUploadDir()).exists()
+        && new File(config.getMachineIdFilePath()).exists());
   }
 }


### PR DESCRIPTION
Readiness depends on 1) having an existing target folder, and 2) having a machine id file.