### PR TITLE
fix: computing the SHA of a file shouldn't require reading all (MWTELE-73)

### DIFF
--- a/api/src/main/java/com/redhat/insights/InsightsReportController.java
+++ b/api/src/main/java/com/redhat/insights/InsightsReportController.java
@@ -161,10 +161,9 @@ public final class InsightsReportController {
    * timestamp for uniqueness here. 2.) this method mutates both the controller and report objects
    */
   void generateAndSetReportIdHash() {
-    String reportJsonNoHash = report.serialize();
     try {
       if (!idHashHolder.isDone()) {
-        String hash = computeSha512(gzipReport(reportJsonNoHash));
+        String hash = computeSha512(gzipReport(report.serialize()));
         idHashHolder.complete(hash);
         report.setIdHash(hash);
       }


### PR DESCRIPTION
the file content.

* Using a DigestInputStream to avoid having the full file content in memory.

Jira: https://issues.redhat.com/browse/MWTELE-73