### PR TITLE
fix: Reduced garbage on InsightsReport's serialization

### DIFF
--- a/api/src/main/java/com/redhat/insights/ObjectMappers.java
+++ b/api/src/main/java/com/redhat/insights/ObjectMappers.java
@@ -1,0 +1,29 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.insights;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * Utility class to provide a factory method for ObjectMapper used by {@link
+ * InsightsReport#serialize} methods
+ */
+class ObjectMappers {
+
+  public static ObjectMapper createFor(InsightsReport insightsReport) {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+
+    SimpleModule simpleModule =
+        new SimpleModule(
+            "SimpleModule", new Version(1, 0, 0, null, "com.redhat.insights", "runtimes-java"));
+    simpleModule.addSerializer(InsightsReport.class, insightsReport.getSerializer());
+    for (InsightsSubreport subreport : insightsReport.getSubreports().values()) {
+      simpleModule.addSerializer(subreport.getClass(), subreport.getSerializer());
+    }
+    mapper.registerModule(simpleModule);
+    return mapper;
+  }
+}

--- a/api/src/main/java/com/redhat/insights/http/InsightsFileWritingClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsFileWritingClient.java
@@ -2,19 +2,15 @@
 package com.redhat.insights.http;
 
 import static com.redhat.insights.InsightsErrorCode.ERROR_UPLOAD_DIR_CREATION;
-import static com.redhat.insights.InsightsErrorCode.ERROR_WRITING_FILE;
 
 import com.redhat.insights.InsightsException;
 import com.redhat.insights.InsightsReport;
 import com.redhat.insights.config.InsightsConfiguration;
 import com.redhat.insights.logging.InsightsLogger;
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 
 public class InsightsFileWritingClient implements InsightsHttpClient {
   private final InsightsLogger logger;
@@ -46,21 +42,10 @@ public class InsightsFileWritingClient implements InsightsHttpClient {
   @Override
   public void sendInsightsReport(String filename, InsightsReport report) {
     decorate(report);
-    String reportJson = report.serialize();
-    //    logger.debug(reportJson);
 
     // Can't reuse upload path - as this may be called as part of fallback
     Path p = Paths.get(config.getArchiveUploadDir(), filename + ".json");
-    try {
-      Files.write(
-          p,
-          reportJson.getBytes(StandardCharsets.UTF_8),
-          StandardOpenOption.WRITE,
-          StandardOpenOption.CREATE,
-          StandardOpenOption.TRUNCATE_EXISTING);
-    } catch (IOException iox) {
-      throw new InsightsException(ERROR_WRITING_FILE, "Could not write to: " + p, iox);
-    }
+    report.serialize(p.toFile());
   }
 
   @Override

--- a/api/src/main/java/com/redhat/insights/http/InsightsHttpClient.java
+++ b/api/src/main/java/com/redhat/insights/http/InsightsHttpClient.java
@@ -7,7 +7,6 @@ import com.redhat.insights.InsightsException;
 import com.redhat.insights.InsightsReport;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPOutputStream;
 
 /**
@@ -46,21 +45,19 @@ public interface InsightsHttpClient {
   default boolean isReadyToSend() {
     return true;
   }
+
   /**
    * Static gzip helper method
    *
    * @param report
    * @return gzipped bytes
    */
-  static byte[] gzipReport(final String report) {
-    try (final ByteArrayOutputStream baos = new ByteArrayOutputStream(report.length())) {
-      final byte[] buffy = report.getBytes(StandardCharsets.UTF_8);
-
+  static byte[] gzipReport(final byte[] report) {
+    try (final ByteArrayOutputStream baos = new ByteArrayOutputStream(report.length)) {
       final GZIPOutputStream gzip = new GZIPOutputStream(baos);
-      gzip.write(buffy, 0, buffy.length);
+      gzip.write(report);
       // An explicit close is necessary before we call toByteArray()
       gzip.close();
-
       return baos.toByteArray();
     } catch (IOException iox) {
       throw new InsightsException(ERROR_GZIP_FILE, "Failed to GZIP report: " + report, iox);

--- a/api/src/main/java/com/redhat/insights/jars/JarInfoSubreport.java
+++ b/api/src/main/java/com/redhat/insights/jars/JarInfoSubreport.java
@@ -11,7 +11,6 @@ import com.redhat.insights.InsightsException;
 import com.redhat.insights.InsightsSubreport;
 import com.redhat.insights.logging.InsightsLogger;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -49,7 +48,8 @@ public class JarInfoSubreport implements InsightsSubreport {
     return new JarInfoSubreportSerializer();
   }
 
-  public String serializeReport() {
+  public byte[] serializeReport() {
+
     ObjectMapper mapper = new ObjectMapper();
 
     SimpleModule simpleModule =
@@ -58,12 +58,10 @@ public class JarInfoSubreport implements InsightsSubreport {
     simpleModule.addSerializer(getClass(), getSerializer());
     mapper.registerModule(simpleModule);
 
-    StringWriter writer = new StringWriter();
     try {
-      mapper.writerWithDefaultPrettyPrinter().writeValue(writer, this);
+      return mapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(this);
     } catch (IOException e) {
       throw new InsightsException(ERROR_SERIALIZING_TO_JSON, "JSON serialization exception", e);
     }
-    return writer.toString();
   }
 }

--- a/api/src/test/java/com/redhat/insights/InsightsReportControllerSimpleThreadingTest.java
+++ b/api/src/test/java/com/redhat/insights/InsightsReportControllerSimpleThreadingTest.java
@@ -50,7 +50,7 @@ public class InsightsReportControllerSimpleThreadingTest {
     report.generateReport(Filtering.DEFAULT);
 
     // First, compute the SHA 512 fingerprint without the id hash
-    String initialReportJson = report.serialize();
+    byte[] initialReportJson = report.serialize();
     final byte[] initialGz = gzipReport(initialReportJson);
     final String hash = computeSha512(initialGz);
 
@@ -62,7 +62,7 @@ public class InsightsReportControllerSimpleThreadingTest {
     assertEquals(controller.getIdHash(), hash);
 
     // Reserialize with the hash
-    final String reportJson = report.serialize();
+    final byte[] reportJson = report.serialize();
     final byte[] finalGz = gzipReport(reportJson);
 
     assertNotEquals(initialReportJson, reportJson);

--- a/api/src/test/java/com/redhat/insights/http/InsightsFileWritingClientTest.java
+++ b/api/src/test/java/com/redhat/insights/http/InsightsFileWritingClientTest.java
@@ -2,12 +2,11 @@
 package com.redhat.insights.http;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.redhat.insights.InsightsException;
 import com.redhat.insights.InsightsReport;
 import com.redhat.insights.config.InsightsConfiguration;
+import com.redhat.insights.doubles.DummyTopLevelReport;
 import com.redhat.insights.doubles.NoopInsightsLogger;
 import com.redhat.insights.logging.InsightsLogger;
 import java.io.File;
@@ -15,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 public class InsightsFileWritingClientTest {
@@ -37,14 +37,13 @@ public class InsightsFileWritingClientTest {
 
     InsightsLogger logger = new NoopInsightsLogger();
     InsightsHttpClient client = new InsightsFileWritingClient(logger, cfg);
-    InsightsReport report = mock(InsightsReport.class);
-    when(report.serialize()).thenReturn("foo");
+    InsightsReport report = new DummyTopLevelReport(logger, Collections.emptyMap());
 
     client.sendInsightsReport("foo", report);
     File[] files = tmpdir.toFile().listFiles();
     assertEquals(1, files.length);
     assertEquals("foo.json", files[0].getName());
-    assertEquals(3, files[0].length());
+    assertEquals(25, files[0].length());
     // Cleanup
     Files.delete(files[0].toPath());
     Files.delete(tmpdir);

--- a/api/src/test/java/com/redhat/insights/it/InsightsReportControllerTest.java
+++ b/api/src/test/java/com/redhat/insights/it/InsightsReportControllerTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.redhat.insights.InsightsException;
 import com.redhat.insights.InsightsReport;
@@ -287,7 +286,7 @@ public class InsightsReportControllerTest {
         });
   }
 
-  private Map<?, ?> parseReport(String report) throws JsonProcessingException {
+  private Map<?, ?> parseReport(byte[] report) throws IOException {
     JsonMapper mapper = new JsonMapper();
     return mapper.readValue(report, Map.class);
   }

--- a/api/src/test/java/com/redhat/insights/jars/JarInfoSubreportTest.java
+++ b/api/src/test/java/com/redhat/insights/jars/JarInfoSubreportTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.redhat.insights.AbstractReportTest;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +42,7 @@ public class JarInfoSubreportTest extends AbstractReportTest {
         "Serializer of JarInfoSubreport should be JarInfoSubreportSerializer");
 
     // generate report
-    String report = subreport.serializeReport();
+    String report = new String(subreport.serializeReport(), StandardCharsets.UTF_8);
 
     // parse report and store it as a key-value map
     Map<?, ?> map = parseReport(report);
@@ -85,7 +86,7 @@ public class JarInfoSubreportTest extends AbstractReportTest {
             logger, Arrays.asList(jarInfoWithoutAttrs, jarInfoWithAttrs, JarInfo.MISSING));
 
     // generate report
-    String report = subreport.serializeReport();
+    String report = new String(subreport.serializeReport(), StandardCharsets.UTF_8);
     Map<?, ?> map = parseReport(report);
 
     assertTrue(map.get("jars") instanceof List, "Jars in report should be parsed as list");
@@ -110,7 +111,7 @@ public class JarInfoSubreportTest extends AbstractReportTest {
     // generate report for jars in current classpath
     classpathJarInfoSubreport.generateReport();
 
-    String report = classpathJarInfoSubreport.serializeReport();
+    String report = new String(classpathJarInfoSubreport.serializeReport(), StandardCharsets.UTF_8);
     Map<?, ?> parsedReport = parseReport(report);
     List<Map<String, ?>> jars = (List<Map<String, ?>>) parsedReport.get("jars");
 


### PR DESCRIPTION
Got a couple of questions before proceeding (adding tests and/or other changes).

It appears that in the multi client case each client serialize the same report many times, but they have the option (for each one) to decorate it:
There is a way to safely assume it won't be changed (by decoration?) and just serialize it once?

I refer to this 
https://github.com/RedHatInsights/insights-java-client/blob/21aca0ca8caec0f3cc28507a53a7770e24b98f55/api/src/main/java/com/redhat/insights/http/InsightsMultiClient.java#L43 code path.
It would be nice to pass through the previously serialized report, during the iteration, if we an assume it to not be changed.