### PR TITLE
fix: make sure we catch all throwables

### DIFF
--- a/api/src/main/java/com/redhat/insights/InsightsCustomScheduledExecutor.java
+++ b/api/src/main/java/com/redhat/insights/InsightsCustomScheduledExecutor.java
@@ -1,4 +1,4 @@
-/* Copyright (C) Red Hat 2023 */
+/* Copyright (C) Red Hat 2023-2024 */
 package com.redhat.insights;
 
 import static com.redhat.insights.InsightsErrorCode.ERROR_SCHEDULED_SENT;
@@ -62,14 +62,14 @@ public class InsightsCustomScheduledExecutor extends ScheduledThreadPoolExecutor
                 ix);
             shutdown();
             throw ix;
-          } catch (Exception x) {
+          } catch (Throwable th) {
             logger.error(
                 ERROR_SCHEDULED_SENT.formatMessage(
                     "Red Hat Insights client scheduler shutdown, non-Insights failure: "
-                        + x.getMessage()),
-                x);
+                        + th.getMessage()),
+                th);
             shutdown();
-            throw x;
+            throw th;
           }
         };
 


### PR DESCRIPTION
Errors were not being caught in the executor, so they were silently ignored. This commit fixes that.

Fixes MWTELE-232
