### PR TITLE
fix: Min and max heap sizes now preferably taken from VM args

### DIFF
--- a/api/src/main/java/com/redhat/insights/reports/AbstractTopLevelReportBase.java
+++ b/api/src/main/java/com/redhat/insights/reports/AbstractTopLevelReportBase.java
@@ -1,4 +1,4 @@
-/* Copyright (C) Red Hat 2022-2023 */
+/* Copyright (C) Red Hat 2022-2024 */
 package com.redhat.insights.reports;
 
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -23,7 +23,9 @@ import java.util.stream.Stream;
  * subreport class and a serializer.
  */
 public abstract class AbstractTopLevelReportBase implements InsightsReport {
+  private static final int BYTES_PER_KB = 1024;
   private static final int BYTES_PER_MB = 1048576;
+  private static final int BYTES_PER_GB = 1073741824;
 
   private static final Pattern JSON_WORKAROUND = Pattern.compile("\\\\+$");
 
@@ -174,14 +176,26 @@ public abstract class AbstractTopLevelReportBase implements InsightsReport {
     options.put("jvm.report_time", System.currentTimeMillis());
     options.put("jvm.pid", getProcessPID());
 
-    MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
-    MemoryUsage heapMemoryUsage = memoryMXBean.getHeapMemoryUsage();
-    options.put("jvm.heap.min", heapMemoryUsage.getInit() / BYTES_PER_MB);
-    options.put("jvm.heap.max", heapMemoryUsage.getMax() / BYTES_PER_MB);
-
     RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
     List<String> inputArguments = fixInputArguments(runtimeMXBean.getInputArguments());
     options.put("jvm.args", inputArguments);
+
+    MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+    MemoryUsage heapMemoryUsage = memoryMXBean.getHeapMemoryUsage();
+    long heapMin = heapMemoryUsage.getInit();
+    long heapMax = heapMemoryUsage.getMax();
+
+    // Check for -Xmn and -Xmx options on the command line
+    for (String arg : inputArguments) {
+      if (arg.startsWith("-Xmn")) {
+        heapMin = getMemorySize(arg.substring(4)).orElse(heapMin);
+      } else if (arg.startsWith("-Xmx")) {
+        heapMax = getMemorySize(arg.substring(4)).orElse(heapMax);
+      }
+    }
+
+    options.put("jvm.heap.min", heapMin / BYTES_PER_MB);
+    options.put("jvm.heap.max", heapMax / BYTES_PER_MB);
 
     List<GarbageCollectorMXBean> gcMxBeans = ManagementFactory.getGarbageCollectorMXBeans();
     StringBuilder gcDetails = new StringBuilder("gc");
@@ -246,6 +260,25 @@ public abstract class AbstractTopLevelReportBase implements InsightsReport {
   static String fixString(String arg) {
     Matcher matcher = JSON_WORKAROUND.matcher(arg);
     return matcher.replaceAll("");
+  }
+
+  static OptionalLong getMemorySize(String size) {
+    if (size == null) {
+      return OptionalLong.empty();
+    }
+    try {
+      if (size.endsWith("k") || size.endsWith("K")) {
+        return OptionalLong.of(Long.parseLong(size.substring(0, size.length() - 1)) * BYTES_PER_KB);
+      } else if (size.endsWith("m") || size.endsWith("M")) {
+        return OptionalLong.of(Long.parseLong(size.substring(0, size.length() - 1)) * BYTES_PER_MB);
+      } else if (size.endsWith("g") || size.endsWith("G")) {
+        return OptionalLong.of(Long.parseLong(size.substring(0, size.length() - 1)) * BYTES_PER_GB);
+      } else {
+        return OptionalLong.of(Long.parseLong(size));
+      }
+    } catch (NumberFormatException e) {
+      return OptionalLong.empty();
+    }
   }
 
   @Override


### PR DESCRIPTION
We now first check if the VM arguments contains `-Xmn` and `-Xmx` options and use them if they are present. If they are not present, we fall back to using `getInit()` and `getMax()` from the `MemoryMXBean`.

Fixes MWTELE-263