### PR TITLE
feat: Move the BackoffWrapper into api

### DIFF
--- a/api/src/main/java/com/redhat/insights/http/BackoffWrapper.java
+++ b/api/src/main/java/com/redhat/insights/http/BackoffWrapper.java
@@ -1,5 +1,5 @@
-/* Copyright (C) Red Hat 2023 */
-package com.redhat.insights.core.httpclient;
+/* Copyright (C) Red Hat 2023-2024 */
+package com.redhat.insights.http;
 
 import static com.redhat.insights.InsightsErrorCode.ERROR_CLIENT_BACKOFF_RETRIES_FAILED;
 import static com.redhat.insights.InsightsErrorCode.ERROR_INTERRUPTED_THREAD;

--- a/api/src/test/java/com/redhat/insights/http/BackoffWrapperTest.java
+++ b/api/src/test/java/com/redhat/insights/http/BackoffWrapperTest.java
@@ -1,5 +1,5 @@
-/* Copyright (C) Red Hat 2023 */
-package com.redhat.insights.core.httpclient;
+/* Copyright (C) Red Hat 2023-2024 */
+package com.redhat.insights.http;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -13,16 +13,16 @@ class BackoffWrapperTest {
 
   @Test
   void notFailingAction() {
-    var logger = PrintLogger.STDOUT_LOGGER;
-    var backoff = new BackoffWrapper(logger, 100L, 2L, 3, () -> {});
+    PrintLogger logger = PrintLogger.STDOUT_LOGGER;
+    BackoffWrapper backoff = new BackoffWrapper(logger, 100L, 2L, 3, () -> {});
     assertEquals(0, backoff.run());
   }
 
   @Test
   void alwaysFailingAction() {
-    var start = System.currentTimeMillis();
-    var logger = PrintLogger.STDOUT_LOGGER;
-    var backoff =
+    long start = System.currentTimeMillis();
+    PrintLogger logger = PrintLogger.STDOUT_LOGGER;
+    BackoffWrapper backoff =
         new BackoffWrapper(
             logger,
             10L,
@@ -45,10 +45,10 @@ class BackoffWrapperTest {
 
   @Test
   void eventuallySucceedingAction() {
-    var start = System.currentTimeMillis();
-    var count = new AtomicInteger(0);
-    var logger = PrintLogger.STDOUT_LOGGER;
-    var backoff =
+    long start = System.currentTimeMillis();
+    AtomicInteger count = new AtomicInteger(0);
+    PrintLogger logger = PrintLogger.STDOUT_LOGGER;
+    BackoffWrapper backoff =
         new BackoffWrapper(
             logger,
             10L,

--- a/runtime/src/main/java/com/redhat/insights/core/httpclient/InsightsJdkHttpClient.java
+++ b/runtime/src/main/java/com/redhat/insights/core/httpclient/InsightsJdkHttpClient.java
@@ -5,6 +5,7 @@ import static com.redhat.insights.InsightsErrorCode.*;
 
 import com.redhat.insights.InsightsException;
 import com.redhat.insights.config.InsightsConfiguration;
+import com.redhat.insights.http.BackoffWrapper;
 import com.redhat.insights.http.InsightsHttpClient;
 import com.redhat.insights.logging.InsightsLogger;
 import com.redhat.insights.reports.InsightsReport;


### PR DESCRIPTION
The BackoffWrapper class is Java 8 compatible (modulo a few vars in the test cases).

This PR moves it into the api module to allow it to be used by Java 8 clients (e.g. the Agent, for v1.0.2)