### PR TITLE
build(deps): bump jackson-core and jackson-databind to 2.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
     <skip.spotless>false</skip.spotless>
 
     <!-- Core dependencies versions -->
-    <jackson-core.version>2.17.1</jackson-core.version>
-    <jackson-databind.version>2.17.1</jackson-databind.version>
+    <jackson-core.version>2.17.2</jackson-core.version>
+    <jackson-databind.version>2.17.2</jackson-databind.version>
     <jackson-datatype-jsr310>2.17.2</jackson-datatype-jsr310>
     <wildfly-elytron.version>2.4.2.Final</wildfly-elytron.version>
 


### PR DESCRIPTION
Bump `jackson-core` and `jackson-databind` to be in sync with previous upgrade to `jackson-datatype-jsr310` raised by dependabot