### PR TITLE
feat: proxies can now be set using HTTPS_PROXY

### DIFF
--- a/api/src/main/java/com/redhat/insights/config/EnvAndSysPropsInsightsConfiguration.java
+++ b/api/src/main/java/com/redhat/insights/config/EnvAndSysPropsInsightsConfiguration.java
@@ -4,6 +4,7 @@ package com.redhat.insights.config;
 import static com.redhat.insights.InsightsErrorCode.ERROR_IDENTIFICATION_NOT_DEFINED;
 
 import com.redhat.insights.InsightsException;
+import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
 import org.jspecify.annotations.NullMarked;
@@ -26,6 +27,7 @@ public class EnvAndSysPropsInsightsConfiguration extends DefaultInsightsConfigur
   public static final String ENV_ARCHIVE_UPLOAD_DIR = "RHT_INSIGHTS_JAVA_ARCHIVE_UPLOAD_DIR";
   public static final String ENV_PROXY_HOST = "RHT_INSIGHTS_JAVA_PROXY_HOST";
   public static final String ENV_PROXY_PORT = "RHT_INSIGHTS_JAVA_PROXY_PORT";
+  public static final String ENV_HTTPS_PROXY = "HTTPS_PROXY";
   public static final String ENV_OPT_OUT = "RHT_INSIGHTS_JAVA_OPT_OUT";
   public static final String ENV_CONNECT_PERIOD = "RHT_INSIGHTS_JAVA_CONNECT_PERIOD";
   public static final String ENV_UPDATE_PERIOD = "RHT_INSIGHTS_JAVA_UPDATE_PERIOD";
@@ -118,7 +120,13 @@ public class EnvAndSysPropsInsightsConfiguration extends DefaultInsightsConfigur
     String host = lookup(ENV_PROXY_HOST);
     String port = lookup(ENV_PROXY_PORT);
     if (host == null || port == null) {
-      return Optional.empty();
+      String httpsProxy = lookup(ENV_HTTPS_PROXY);
+      if (httpsProxy == null) {
+        return Optional.empty();
+      }
+      URI proxyUri = URI.create(httpsProxy);
+      host = proxyUri.getHost();
+      port = Integer.toString(proxyUri.getPort());
     }
     return Optional.of(new ProxyConfiguration(host, Integer.parseUnsignedInt(port)));
   }

--- a/api/src/test/java/com/redhat/insights/configuration/EnvVariableConfigurationTest.java
+++ b/api/src/test/java/com/redhat/insights/configuration/EnvVariableConfigurationTest.java
@@ -1,4 +1,4 @@
-/* Copyright (C) Red Hat 2023 */
+/* Copyright (C) Red Hat 2023-2024 */
 package com.redhat.insights.configuration;
 
 import static com.redhat.insights.config.EnvAndSysPropsInsightsConfiguration.*;
@@ -94,6 +94,33 @@ public class EnvVariableConfigurationTest {
         "Configuration does not contain value passed through environment variable.");
     assertEquals(
         12345,
+        config.getProxyConfiguration().get().getPort(),
+        "Configuration does not contain value passed through environment variable.");
+  }
+
+  @Test
+  void testGetProxyConfigurationWithUnusedEnv() {
+    environmentVariables.set(ENV_HTTPS_PROXY, "https://env-https-proxy-host:54321");
+    assertEquals(
+        "env-proxy-host",
+        config.getProxyConfiguration().get().getHost(),
+        "Configuration does not contain value passed through environment variable.");
+    assertEquals(
+        12345,
+        config.getProxyConfiguration().get().getPort(),
+        "Configuration does not contain value passed through environment variable.");
+  }
+
+  @Test
+  void testGetProxyConfigurationAlternative() {
+    environmentVariables.remove(ENV_PROXY_HOST).remove(ENV_PROXY_PORT);
+    environmentVariables.set(ENV_HTTPS_PROXY, "https://env-https-proxy-host:54321");
+    assertEquals(
+        "env-https-proxy-host",
+        config.getProxyConfiguration().get().getHost(),
+        "Configuration does not contain value passed through environment variable.");
+    assertEquals(
+        54321,
         config.getProxyConfiguration().get().getPort(),
         "Configuration does not contain value passed through environment variable.");
   }


### PR DESCRIPTION
For now this simply extracts the host and port from the proxy URL and uses those to connect, just if we were using the RHT_INSIGHTS_JAVA_PROXY_HOST and PORT variables.

This very likely too simple. First I'm not really sure if using RHT_INSIGHTS_JAVA_PROXY_HOST/PORT actually connects using SSL or not and secondly a proxy URL could contain authentication information which we don't use right now.

Fixes MWTELE-42