### PR TITLE
build(deps): upgrade jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
 
     <!-- Core dependencies versions -->
     <jackson-core.version>2.18.0</jackson-core.version>
-    <jackson-databind.version>2.17.2</jackson-databind.version>
-    <jackson-datatype-jsr310>2.17.2</jackson-datatype-jsr310>
+    <jackson-databind.version>2.18.0</jackson-databind.version>
+    <jackson-datatype-jsr310>2.18.0</jackson-datatype-jsr310>
     <wildfly-elytron.version>2.6.0.Final</wildfly-elytron.version>
 
     <!-- Test libraries versions -->


### PR DESCRIPTION
Dependabot upgraded jackson-core recently, upgrade the other Jackson deps to keep them in sync